### PR TITLE
RenderLoop never ended, don't requestAnimationFrame after destroy

### DIFF
--- a/src/GlslCanvas.js
+++ b/src/GlslCanvas.js
@@ -150,6 +150,9 @@ void main(){
 
         let sandbox = this;
         function RenderLoop() {
+            if (!sandbox.gl) {
+                return
+            }
             if (sandbox.nMouse > 1) {
                 sandbox.setMouse(mouse);
             }


### PR DESCRIPTION
Even after invoking [destroy](https://github.com/patriciogonzalezvivo/glslCanvas/blob/aa852ebe45f835740defae7380e4e8e054d85aa9/src/GlslCanvas.js#L167), [RenderLoop](https://github.com/patriciogonzalezvivo/glslCanvas/blob/aa852ebe45f835740defae7380e4e8e054d85aa9/src/GlslCanvas.js#L152) will keep firing forever.

Check if `gl` exists before invoking the next `RenderLoop` and subsequent `requestAnimationFrame`