### PR TITLE
When destroying textures invoke Texture.destroy and avoid a TypeError

### DIFF
--- a/src/GlslCanvas.js
+++ b/src/GlslCanvas.js
@@ -171,7 +171,9 @@ void main(){
         this.animated = false;
         this.isValid = false;
         for (let tex in this.textures) {
-            this.gl.deleteTexture(tex);
+            if (tex.destroy){
+                tex.destroy()
+            }
         }
         this.textures = {};
         for (let att in this.attribs) {


### PR DESCRIPTION
`Texture` has its own [destroy](https://github.com/giannif/glslCanvas/blob/fix/destroy-error-with-textures/src/gl/Texture.js#L31) method, use that to avoid a TypeError 

In [GlslCanvas.destroy](https://github.com/giannif/glslCanvas/blob/fix/destroy-error-with-textures/src/GlslCanvas.js#L175), instead of:
```javascript
for (let tex in this.textures) {
  // Throws error: Failed to execute 'deleteTexture' on 'WebGLRenderingContext': 
  // parameter 1 is not of type 'WebGLTexture'.
  this.gl.deleteTexture(tex);
}
```

`this.gl.deleteTexture(tex.texture);` is what we want to delete, but we can also do this:
```javascript
for (let tex in this.textures) {  
  if (tex.destroy){
    tex.destroy()
  }
}
```
