### PR TITLE
Fix .babelrc and add travis

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
+// babel-env-disable
 {
     "presets": [
         [

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+- node
+cache: yarn
+script:
+- npm run build
+notifications:
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
- Fixes the issue with `babel-env` overwriting `.babelrc` when running `yarn` with an empty `node_modules`
- Adds basic travis configuration to make sure the build succeeds 

Successful build: 
https://travis-ci.org/giannif/glslCanvas/builds/324342438

If you want to add travis to this project, you'll have to turn it on by logging into github on https://travis-ci.org and enabling the repo.

Ideally, we'd add tests and linting, but I'll leave that for a future PR 