### PR TITLE
add fullscreen options

### DIFF
--- a/src/GlslCanvas.js
+++ b/src/GlslCanvas.js
@@ -34,8 +34,18 @@ export default class GlslCanvas {
         contextOptions = contextOptions || {};
         options = options || {};
 
-        this.width = canvas.clientWidth;
-        this.height = canvas.clientHeight;
+        if (canvas.hasAttribute('data-fullscreen') &&
+            (canvas.getAttribute('data-fullscreen') == "1" ||
+            canvas.getAttribute('data-fullscreen') == "true" )
+        ) {
+            this.width = window.innerWidth;
+            this.height = window.innerHeight;
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+        } else {
+            this.width = canvas.clientWidth;
+            this.height = canvas.clientHeight;
+        }
 
         this.canvas = canvas;
         this.gl = undefined;


### PR DESCRIPTION
It works by simply adding `data-fullscreen="true"` or `data-fullscreen="1"` attribute to the canvas tag, tested locally on chrome and firefox.