### PR TITLE
Add muted attribute + play call for videos to work

### DIFF
--- a/src/gl/Texture.js
+++ b/src/gl/Texture.js
@@ -89,6 +89,13 @@ export default class Texture {
             if (isVideo) {
                 element = document.createElement('video');
                 element.autoplay = true;
+                
+                
+                element.muted = true; /* required for modern browsers to autoplay video */
+                setTimeout(function () {
+                    element.play() /* doesn't block promise but needs a more elegant solution */
+                }, 1);
+                
                 options.filtering = 'nearest';
                 // element.preload = 'auto';
                 // element.style.display = 'none';


### PR DESCRIPTION
- Add muted attribute to video element to allow autoplay for modern browsers.
- Add a simple timeout to trigger video play, since autoplay wasn't working. Needs a more elegant solution though